### PR TITLE
Update postgraphile-express-typescript-example.mts

### DIFF
--- a/postgraphile-express-typescript-example.mts
+++ b/postgraphile-express-typescript-example.mts
@@ -7,7 +7,7 @@ export const pgl = postgraphile(preset);
 
 import { createServer } from "node:http";
 import express from "express";
-import { grafserv } from "grafserv/express/v4";
+import { grafserv } from "postgraphile/grafserv/express/v4";
 
 const serv = pgl.createServ(grafserv);
 


### PR DESCRIPTION
Since `grafserv` is not declared as a dependency, to be able to run ouch-my-finger in my yarn monorepo, I need to import grafserv from postgraphile. This solves all my problems including https://github.com/benjie/crystal/issues/379 , I am now able to run postgraphile v5 in my monorepo !