### PR TITLE
build.getTypeByName bug repro

### DIFF
--- a/graphile.config.mjs
+++ b/graphile.config.mjs
@@ -2,26 +2,37 @@
 import { makePgService } from "@dataplan/pg/adaptors/pg";
 import AmberPreset from "postgraphile/presets/amber";
 import { makeV4Preset } from "postgraphile/presets/v4";
-import { PostGraphileConnectionFilterPreset } from "postgraphile-plugin-connection-filter";
-import { PgAggregatesPreset } from "@graphile/pg-aggregates";
-import { PgManyToManyPreset } from "@graphile-contrib/pg-many-to-many";
-// import { PgSimplifyInflectionPreset } from "@graphile/simplify-inflection";
 
 // For configuration file details, see: https://postgraphile.org/postgraphile/next/config
+
+import { gql, makeExtendSchemaPlugin } from 'postgraphile/utils';
+
+
+const Pharmacy = makeExtendSchemaPlugin(() => {
+	return {
+		typeDefs: gql`
+			interface IPharmacy {
+				id: String!
+			}
+
+			type Pharmacy implements IPharmacy {
+				id: String!
+			}
+		`,
+	};
+});
+
 
 /** @satisfies {GraphileConfig.Preset} */
 const preset = {
   extends: [
-    AmberPreset.default ?? AmberPreset,
+    AmberPreset.default,
     makeV4Preset({
       /* Enter your V4 options here */
       graphiql: true,
       graphiqlRoute: "/",
+      appendPlugins: [Pharmacy]
     }),
-    PostGraphileConnectionFilterPreset,
-    PgManyToManyPreset,
-    PgAggregatesPreset,
-    // PgSimplifyInflectionPreset
   ],
   pgServices: [
     makePgService({


### PR DESCRIPTION
```
$ env DATABASE_URL=… DATABASE_SCHEMAS=… npx ts-node --esm postgraphile-express-typescript-example.mts
npm WARN config init.author.name Use `--init-author-name` instead.
npm WARN config init.author.email Use `--init-author-email` instead.
npm WARN config init.author.url Use `--init-author-url` instead.
Server listening at http://localhost:5678
Error: Must not call build.getTypeByName before 'init' phase is complete
    at Object.getTypeByName (/Users/iris/Software/folx/ouch-my-finger/node_modules/graphile-build/src/makeNewBuild.ts:362:15)
    at /Users/iris/Software/folx/ouch-my-finger/node_modules/graphile-utils/src/makeExtendSchemaPlugin.ts:828:20
    at Array.map (<anonymous>)
    at getInterfaces (/Users/iris/Software/folx/ouch-my-finger/node_modules/graphile-utils/src/makeExtendSchemaPlugin.ts:827:23)
    at /Users/iris/Software/folx/ouch-my-finger/node_modules/graphile-utils/src/makeExtendSchemaPlugin.ts:372:34
    at Array.forEach (<anonymous>)
    at init (/Users/iris/Software/folx/ouch-my-finger/node_modules/graphile-utils/src/makeExtendSchemaPlugin.ts:310:20)
    at SchemaBuilder.applyHooks (/Users/iris/Software/folx/ouch-my-finger/node_modules/graphile-build/src/SchemaBuilder.ts:164:20)
    at SchemaBuilder.createBuild (/Users/iris/Software/folx/ouch-my-finger/node_modules/graphile-build/src/SchemaBuilder.ts:244:10)
    at SchemaBuilder.buildSchema (/Users/iris/Software/folx/ouch-my-finger/node_modules/graphile-build/src/SchemaBuilder.ts:254:24)
```