### PR TITLE
query:resource:single broken?

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -1,0 +1,13 @@
+version: '3.8'
+
+services:
+  postgres:
+    image: postgres:latest
+    environment:
+      POSTGRES_DB: appdb
+      POSTGRES_USER: appuser
+      POSTGRES_PASSWORD: apppassword
+    ports:
+      - "5432:5432"
+    volumes:
+      - ./init-script.sql:/docker-entrypoint-initdb.d/init-script.sql

--- a/init-script.sql
+++ b/init-script.sql
@@ -1,0 +1,36 @@
+CREATE SCHEMA app_public;
+
+GRANT USAGE ON SCHEMA app_public TO appuser;
+
+CREATE TABLE app_public.items (
+    id SERIAL PRIMARY KEY,
+    name TEXT NOT NULL
+);
+
+CREATE TABLE app_public.users (
+    id SERIAL PRIMARY KEY,
+    item_id SERIAL, 
+    CONSTRAINT fk_items
+      FOREIGN KEY(item_id) 
+	  REFERENCES app_public.items(id)
+	  ON DELETE CASCADE
+);
+
+ALTER TABLE app_public.users ENABLE ROW LEVEL SECURITY;
+ALTER TABLE app_public.items ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY select_all ON app_public.users
+    FOR SELECT
+    USING (true);
+
+CREATE POLICY select_all ON app_public.items
+    FOR SELECT
+    USING (true);
+
+COMMENT ON TABLE app_public.users IS $$
+@behavior -query:resource:connection
+$$;
+
+COMMENT ON TABLE app_public.items IS $$
+@behavior -query:resource:connection -query:resource:single
+$$;

--- a/server-express.mjs
+++ b/server-express.mjs
@@ -1,6 +1,6 @@
 // @ts-check
 import express from "express";
-import { grafserv } from "grafserv/express/v4";
+import { grafserv } from "postgraphile/grafserv/express/v4";
 import { postgraphile } from "postgraphile";
 import preset from "./graphile.config.mjs";
 


### PR DESCRIPTION
I've made a super simple example and it seems like `-query:resource:single` is not working as expected.

```bash
yarn
docker-compose up
yarn postgraphile -c postgres://appuser:apppassword@localhost:5432/appdb -s app_public

# Easily restart postgres with new sql from init-script.sql
# docker-compose down -v && docker-compose up
```

As the image. I would except that `item` would not be accessible. It seems to remove `itemById` but not `item`.

![image](https://github.com/benjie/ouch-my-finger/assets/476567/e6aa333e-b981-4f63-95f7-cf2ccbebe7f7)

The expected behavior I believe is that `item` should not be accessible from the root query but should be accessible from `User`.