### PR TITLE
minimal repro for `GrafastInternalError`

### DIFF
--- a/broken-plugin.mjs
+++ b/broken-plugin.mjs
@@ -1,0 +1,23 @@
+import { withPgClient } from "@dataplan/pg";
+import { list } from "postgraphile/grafast";
+import { makeWrapPlansPlugin } from "postgraphile/utils";
+
+export const BrokenPlugin = makeWrapPlansPlugin((build) => {
+  const { test } = build.input.pgRegistry.pgResources;
+  if (!test) throw new Error("Resources not found");
+
+  return {
+    Mutation: {
+      createTest(plan) {
+        const $step = withPgClient(
+          test.executor,
+          list([]),
+          async (_client) => {}
+        );
+
+        $step.hasSideEffects = true;
+        return plan();
+      },
+    },
+  };
+});

--- a/graphile.config.mjs
+++ b/graphile.config.mjs
@@ -8,6 +8,7 @@ import { PgManyToManyPreset } from "@graphile-contrib/pg-many-to-many";
 // import { PgSimplifyInflectionPreset } from "@graphile/simplify-inflection";
 import PersistedPlugin from "@grafserv/persisted";
 import { PgOmitArchivedPlugin } from "@graphile-contrib/pg-omit-archived";
+import { BrokenPlugin } from "./broken-plugin.mjs";
 
 // For configuration file details, see: https://postgraphile.org/postgraphile/next/config
 
@@ -25,7 +26,7 @@ const preset = {
     PgAggregatesPreset,
     // PgSimplifyInflectionPreset
   ],
-  plugins: [PersistedPlugin.default, PgOmitArchivedPlugin],
+  plugins: [PersistedPlugin.default, PgOmitArchivedPlugin, BrokenPlugin],
   pgServices: [
     makePgService({
       // Database connection string:

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   },
   "dependencies": {
     "@grafserv/persisted": "^0.0.0-beta.24",
-    "@graphile-contrib/pg-many-to-many": "^2.0.0-beta.1",
+    "@graphile-contrib/pg-many-to-many": "^2.0.0-beta.3",
     "@graphile-contrib/pg-omit-archived": "^4.0.0-beta.3",
     "@graphile/pg-aggregates": "^0.2.0-beta.6",
     "@graphile/simplify-inflection": "^8.0.0-beta.5",


### PR DESCRIPTION
```Masked GraphQL error (hash: 'ofYBOfZIA3RnSvLB7a-o8AMwF8g', id: 'W7RGBMG7XE')
GrafastInternalError<da9cc5a0-23bf-4af8-a103-92f995795398>: WithPgClient{1}➊[11] has no entry in Bucket<LayerPlan<1∈0?mutationField!x>>

GraphQL HTTP Request:2:3
1 | mutation MyMutation {
2 |   createTest(input: {test: {}}) {
  |   ^
3 |     clientMutationId
Error: GrafastInternalError<da9cc5a0-23bf-4af8-a103-92f995795398>: WithPgClient{1}➊[11] has no entry in Bucket<LayerPlan<1∈0?mutationField!x>>
    at OutputPlan.fn [as execute] (/Users/sje/dev/ouch-my-finger/node_modules/grafast/dist/engine/OutputPlan.js:461:27)
    at executeChildPlan (/Users/sje/dev/ouch-my-finger/node_modules/grafast/dist/engine/OutputPlan.js:545:79)
    at OutputPlan.inner (/Users/sje/dev/ouch-my-finger/node_modules/grafast/dist/engine/OutputPlan.js:977:37)
    at OutputPlan.fn [as execute] (/Users/sje/dev/ouch-my-finger/node_modules/grafast/dist/engine/OutputPlan.js:484:22)
    at executeOutputPlan (/Users/sje/dev/ouch-my-finger/node_modules/grafast/dist/engine/executeOutputPlan.js:24:22)
    at outputBucket (/Users/sje/dev/ouch-my-finger/node_modules/grafast/dist/prepare.js:162:69)
    at output (/Users/sje/dev/ouch-my-finger/node_modules/grafast/dist/prepare.js:332:31)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
Masked GraphQL error (hash: 'ofYBOfZIA3RnSvLB7a-o8AMwF8g', id: '477D2PXDHV')
GrafastInternalError<da9cc5a0-23bf-4af8-a103-92f995795398>: WithPgClient{1}➊[11] has no entry in Bucket<LayerPlan<1∈0?mutationField!x>>
```