### PR TITLE
[DO NOT MERGE] Minimum reproduction of unexpected nulled date arrays

### DIFF
--- a/example.schema.sql
+++ b/example.schema.sql
@@ -1,0 +1,38 @@
+CREATE DATABASE example;
+CREATE SCHEMA example;
+CREATE TABLE example.test (
+    id SERIAL PRIMARY KEY,
+    foo text[] NOT NULL,
+    bar date[] NOT NULL,
+    baz text[],
+    bing date[]
+);
+ALTER TABLE example.test ENABLE ROW LEVEL SECURITY;
+
+INSERT INTO example.test(id, foo, bar, baz, bing) VALUES (1, '{}', '{}', '{}', '{}');
+INSERT INTO example.test(id, foo, bar, baz, bing) VALUES (2, '{"foo"}', '{2024-11-11}', '{"baz"}', '{2024-11-11}');
+
+-- In the graphile UI
+-- Fetch row 1 without bar resolves as expected
+--
+-- query MyQuery {
+--   test(rowId: 1) {
+--     id
+--     foo
+--     rowId
+--   }
+-- }
+--
+-- With bar failes to resolved with error 'Masked GraphQL error (hash: '8-OScfAOPZ-V_3XKL6FgJJXI8ZY', id: 'A7XBZW9BQU') GraphQLError: Cannot return null for non-nullable field Test.bar.'
+--
+-- query MyQuery {
+--   test(rowId: 1) {
+--     id
+--     foo
+--     bar
+--     rowId
+--   }
+-- }
+--
+-- Record 2 provided as an example of where it works as intended
+-- NOTE: Swapping foo,bar for baz,bing on the above table which do not have the NOT NULL constraints has the empty date[] array being resolved as null inconsistent with the text[] array.

--- a/graphile.config.mjs
+++ b/graphile.config.mjs
@@ -1,13 +1,13 @@
 // @ts-check
 import { makePgService } from "@dataplan/pg/adaptors/pg";
 import AmberPreset from "postgraphile/presets/amber";
-import { makeV4Preset } from "postgraphile/presets/v4";
+// import { makeV4Preset } from "postgraphile/presets/v4";
 import { PostGraphileConnectionFilterPreset } from "postgraphile-plugin-connection-filter";
 import { PgAggregatesPreset } from "@graphile/pg-aggregates";
-import { PgManyToManyPreset } from "@graphile-contrib/pg-many-to-many";
-// import { PgSimplifyInflectionPreset } from "@graphile/simplify-inflection";
+// import { PgManyToManyPreset } from "@graphile-contrib/pg-many-to-many";
+import { PgSimplifyInflectionPreset } from "@graphile/simplify-inflection";
 import PersistedPlugin from "@grafserv/persisted";
-import { PgOmitArchivedPlugin } from "@graphile-contrib/pg-omit-archived";
+// import { PgOmitArchivedPlugin } from "@graphile-contrib/pg-omit-archived";
 
 // For configuration file details, see: https://postgraphile.org/postgraphile/next/config
 
@@ -15,17 +15,15 @@ import { PgOmitArchivedPlugin } from "@graphile-contrib/pg-omit-archived";
 const preset = {
   extends: [
     AmberPreset.default ?? AmberPreset,
-    makeV4Preset({
-      /* Enter your V4 options here */
-      graphiql: true,
-      graphiqlRoute: "/",
-    }),
     PostGraphileConnectionFilterPreset,
-    PgManyToManyPreset,
+    // PgManyToManyPreset,
+    PgSimplifyInflectionPreset,
     PgAggregatesPreset,
-    // PgSimplifyInflectionPreset
   ],
-  plugins: [PersistedPlugin.default, PgOmitArchivedPlugin],
+  plugins: [
+    PersistedPlugin.default,
+    // PgOmitArchivedPlugin
+  ],
   pgServices: [
     makePgService({
       // Database connection string:
@@ -36,6 +34,9 @@ const preset = {
       pubsub: true,
     }),
   ],
+  schema: {
+    dontSwallowErrors: true
+  },
   grafserv: {
     port: 5678,
     websockets: true,


### PR DESCRIPTION
Example database setup in `example.schema.sql`. 

Date arrays are being parsed as null when empty which leads to a masked error if a non-null constraint is on the column.

`Masked GraphQL error (hash: '8-OScfAOPZ-V_3XKL6FgJJXI8ZY', id: 'A7XBZW9BQU') GraphQLError: Cannot return null for non-nullable field Test.bar.`

If the datatype is nullable the empty date array is returned as null rather than an empty array which is inconsistent with how text arrays are handled.

Query 1 (No error, correct data):
```
query MyQuery {
  test(rowId: 2) {
    id
    rowId
    foo
    bar
    baz
    bing
  }
}
```

```
{
  "data": {
    "test": {
      "id": "WyJUZXN0IiwyXQ==",
      "rowId": 2,
      "foo": [
        "foo"
      ],
      "bar": [
        "2024-11-11"
      ],
      "baz": [
        "baz"
      ],
      "bing": [
        "2024-11-11"
      ]
    }
  }
}
```

Query 2 (No error, correct data):
```
query MyQuery {
  test(rowId: 1) {
    id
    rowId
    foo
    baz
  }
}
```

```
{
  "data": {
    "test": {
      "id": "WyJUZXN0IiwxXQ==",
      "rowId": 1,
      "foo": [],
      "baz": []
    }
  }
}
```

Query 3 (Inconsistent Response):
```
query MyQuery {
  test(rowId: 1) {
    id
    rowId
    foo
    baz
    bing
  }
}
```

```
{
  "data": {
    "test": {
      "id": "WyJUZXN0IiwxXQ==",
      "rowId": 1,
      "foo": [],
      "baz": [],
      "bing": null
    }
  }
}
```

Query 4 (Error):
```
query MyQuery {
  test(rowId: 1) {
    id
    rowId
    foo
    bar
    baz
    bing
  }
}
```

```
{
  "data": {
    "test": null
  },
  "errors": [
    {
      "message": "An error occurred (logged with hash: 'z_PBVe3UH5AXpLia2Jn5_AOlz9I', id: 'R9KN3L9JYH')",
      "locations": [
        {
          "line": 6,
          "column": 5
        }
      ],
      "path": [
        "test",
        "bar"
      ],
      "extensions": {
        "errorId": "R9KN3L9JYH"
      }
    }
  ]
}
```